### PR TITLE
change how location of EdgeMarkers are calculated

### DIFF
--- a/Leaflet.EdgeMarker.js
+++ b/Leaflet.EdgeMarker.js
@@ -147,6 +147,24 @@
               markerDistance = currentMarkerPosition.x - mapPixelBounds.x;
             }
           }
+          // correction so that is always has same distance to edge
+
+          // top out (top has y=0)
+          if (y <  markerHeight/2) {
+            y = markerHeight/2;
+            // bottom out
+          }
+          else if (y > mapPixelBounds.y - markerHeight/2) {
+            y = mapPixelBounds.y - markerHeight/2 ;
+          }
+          // right out
+          if (x > mapPixelBounds.x- markerWidth / 2) {
+            x = mapPixelBounds.x - markerWidth / 2;
+            // left out
+          } else if (x < markerWidth / 2) {
+            x = markerWidth / 2;
+          }
+
           // change opacity on distance
           var newOptions = this.options;
           if (this.options.distanceOpacity) {

--- a/Leaflet.EdgeMarker.js
+++ b/Leaflet.EdgeMarker.js
@@ -107,26 +107,46 @@
           var y = currentMarkerPosition.y;
           var markerDistance;
 
-          // top out
-          if (currentMarkerPosition.y < 0) {
-            y = 0 + markerHeight / 2;
-            markerDistance = -currentMarkerPosition.y;
+          // we want to place EdgeMarker on the line from center screen to target,
+          // and against the border of the screen
+          // we know angel and its x or y cordiante
+          // (depending if we want to place it against top/bottom edge or left right edge)
+          // fromthat we can calculate the other cordinate
+
+          var center = L.point(mapPixelBounds.x/2,mapPixelBounds.y/2);
+
+          var rad = Math.atan2(center.y - y, center.x - x);
+          var rad2TopLeftcorner = Math.atan2(center.y,center.x);
+
+          // target is in between diagonals window/ hourglass
+          // more out in y then in x
+          if (Math.abs(rad) > rad2TopLeftcorner && Math.abs (rad) < Math.PI -rad2TopLeftcorner) {
+
             // bottom out
-          } else if (currentMarkerPosition.y > mapPixelBounds.y) {
-            y = mapPixelBounds.y - markerHeight / 2;
-            markerDistance = currentMarkerPosition.y - mapPixelBounds.y;
-          }
+            if (y < center.y ){
+              y = markerHeight/2;
+              x = center.x -  (center.y-y) / Math.tan(Math.abs(rad));
+              markerDistance = currentMarkerPosition.y - mapPixelBounds.y;
+            // top out
+            }else{
+              y = mapPixelBounds.y - markerHeight/2;
+              x = center.x -  (y-center.y)/ Math.tan(Math.abs(rad));
+              markerDistance = -currentMarkerPosition.y;
+            }
+          }else {
 
-          // right out
-          if (currentMarkerPosition.x > mapPixelBounds.x) {
-            x = mapPixelBounds.x - markerWidth / 2;
-            markerDistance = currentMarkerPosition.x - mapPixelBounds.x;
             // left out
-          } else if (currentMarkerPosition.x < 0) {
-            x = 0 + markerWidth / 2;
-            markerDistance = -currentMarkerPosition.x;
+            if (x < center.x ){
+              x = markerWidth/2;
+              y = center.y -  (center.x-x ) *Math.tan(rad);
+              markerDistance = -currentMarkerPosition.x;
+            // right out
+            }else{
+              x = mapPixelBounds.x - markerWidth/2;
+              y = center.y +  (x - center.x) *Math.tan(rad);
+              markerDistance = currentMarkerPosition.x - mapPixelBounds.x;
+            }
           }
-
           // change opacity on distance
           var newOptions = this.options;
           if (this.options.distanceOpacity) {
@@ -136,9 +156,7 @@
 
           // rotate markers
           if (this.options.rotateIcons) {
-            var centerX = mapPixelBounds.x / 2;
-            var centerY = mapPixelBounds.y / 2;
-            var angle = Math.atan2(centerY - y, centerX - x) / Math.PI * 180;
+            var angle = rad / Math.PI * 180;
             newOptions.angle = angle;
           }
 


### PR DESCRIPTION
the original just used the x or y coordinates of target.
this is close to correct. For example:
if you have EdgeMarker for a point very far away to left and bit more north.
edge maker will be placed in the corner. because both x and y are from outside screen reach.
this gives the impression that target is in direction of that corner.
but in reality it's to your left(and a small bit up)

the new implementation place marker on the intersection of line from
center of creen to target and the edge

its has small fault:
is place the marker with small offset from edge of  the screen
this offset is the height of icon for top/bottom and with for
left/right edge
this gives incorrect result if icon is not square and rotated

i tried to keep distance opacity the same but have not tested it

second commit is nor really necessary. but makes bit smoother